### PR TITLE
Add class implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,72 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
     <groupId>io.github.akuniutka</groupId>
     <artifactId>base-jpa-entity</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <java.version>17</java.version>
+        <java-uuid-generator.version>5.1.0</java-uuid-generator.version>
+
+        <argLine>-XX:+EnableDynamicAgentLoading -Xshare:off</argLine>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.uuid</groupId>
+            <artifactId>java-uuid-generator</artifactId>
+            <version>${java-uuid-generator.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/io/github/akuniutka/BaseJpaEntity.java
+++ b/src/main/java/io/github/akuniutka/BaseJpaEntity.java
@@ -1,0 +1,55 @@
+package io.github.akuniutka;
+
+import com.fasterxml.uuid.Generators;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@MappedSuperclass
+public abstract class BaseJpaEntity {
+
+    @Id
+    private UUID id;
+
+    protected BaseJpaEntity() {
+        this(Generators.timeBasedEpochGenerator().generate());
+    }
+
+    protected BaseJpaEntity(final UUID id) {
+        Objects.requireNonNull(id);
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public final boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        final Class<?> thisEffectiveClass = this instanceof HibernateProxy proxy
+                ? proxy.getHibernateLazyInitializer().getPersistentClass()
+                : this.getClass();
+        final Class<?> objEffectiveClass = obj instanceof HibernateProxy proxy
+                ? proxy.getHibernateLazyInitializer().getPersistentClass()
+                : obj.getClass();
+        if (thisEffectiveClass != objEffectiveClass) {
+            return false;
+        }
+        final BaseJpaEntity entity = (BaseJpaEntity) obj;
+        return Objects.equals(getId(), entity.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(getId());
+    }
+}

--- a/src/test/java/io/github/akuniutka/ImplementationsComparisonTest.java
+++ b/src/test/java/io/github/akuniutka/ImplementationsComparisonTest.java
@@ -1,0 +1,168 @@
+package io.github.akuniutka;
+
+import io.github.akuniutka.model.PhoneWithCustomEqualsAndHashCode;
+import io.github.akuniutka.model.PhoneWithLombokEqualsAndHashCode;
+import io.github.akuniutka.model.PhoneWithLombokEqualsAndHashCodeAdjusted;
+import io.github.akuniutka.model.PhoneWithProperEqualsAndHashCode;
+import io.github.akuniutka.model.UserWithDefaultEqualsAndHashCode;
+import io.github.akuniutka.model.UserWithLombokEqualsAndHashCode;
+import io.github.akuniutka.model.UserWithProperEqualsAndHashCode;
+import io.github.akuniutka.repository.PhoneWithCustomEqualsAndHashCodeRepository;
+import io.github.akuniutka.repository.PhoneWithLombokEqualsAndHashCodeAdjustedRepository;
+import io.github.akuniutka.repository.PhoneWithLombokEqualsAndHashCodeRepository;
+import io.github.akuniutka.repository.PhoneWithProperEqualsAndHashCodeRepository;
+import io.github.akuniutka.repository.UserWithDefaultEqualsAndHashCodeRepository;
+import io.github.akuniutka.repository.UserWithLombokEqualsAndHashCodeAdjustedRepository;
+import io.github.akuniutka.repository.UserWithLombokEqualsAndHashCodeRepository;
+import io.github.akuniutka.repository.UserWithProperEqualsAndHashCodeRepository;
+import org.hibernate.Hibernate;
+import org.hibernate.LazyInitializationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@SpringBootTest
+class ImplementationsComparisonTest {
+
+    private final UUID userId = UUID.fromString("871bc130-0b36-49ae-b631-b298b95e9478");
+    private final UUID phoneId = UUID.fromString("0749be04-2188-491b-b62c-83c717c69671");
+
+    @Autowired
+    private UserWithDefaultEqualsAndHashCodeRepository userDefaultRepository;
+
+    @Autowired
+    private UserWithLombokEqualsAndHashCodeRepository userLombokRepository;
+
+    @Autowired
+    private UserWithLombokEqualsAndHashCodeAdjustedRepository userLombokAdjustedRepository;
+
+    @Autowired
+    private UserWithProperEqualsAndHashCodeRepository userProperRepository;
+
+    @Autowired
+    private PhoneWithLombokEqualsAndHashCodeRepository phoneLombokRepository;
+
+    @Autowired
+    private PhoneWithLombokEqualsAndHashCodeAdjustedRepository phoneLombokAdjustedRepository;
+
+    @Autowired
+    private PhoneWithCustomEqualsAndHashCodeRepository phoneCustomRepository;
+
+    @Autowired
+    private PhoneWithProperEqualsAndHashCodeRepository phoneProperRepository;
+
+    @Test
+    void whenDefaultEqualsAndHashCode_ThenSameEntityInstancesFromDifferentTransactionsAreNotEqual() {
+
+        final UserWithDefaultEqualsAndHashCode user = userDefaultRepository.findById(userId).orElseThrow();
+        final List<UserWithDefaultEqualsAndHashCode> users = userDefaultRepository.findAll();
+
+        assertFalse(users.contains(user));
+    }
+
+    @Test
+    void whenProperEqualsAndHashCode_ThenSameEntityInstanceFromDifferentTransactionsAreEqual() {
+
+        final UserWithProperEqualsAndHashCode user = userProperRepository.findById(userId).orElseThrow();
+        final List<UserWithProperEqualsAndHashCode> users = userProperRepository.findAll();
+
+        assertTrue(users.contains(user));
+    }
+
+    @Test
+    void whenLombokEqualsAndHashCode_ThenSameEntityInstancesWithDifferentSecondaryFieldValuesAreNotEqual() {
+
+        final PhoneWithLombokEqualsAndHashCode phone = phoneLombokRepository.findById(phoneId).orElseThrow();
+        phone.setType("mobile");
+        final List<PhoneWithLombokEqualsAndHashCode> phones = phoneLombokRepository.findAll();
+
+        assertFalse(phones.contains(phone));
+    }
+
+    @Test
+    void whenLombokEqualsAndHashCode_ThenLoadFieldsWithLazyInitialization() {
+
+        final UserWithLombokEqualsAndHashCode user = userLombokRepository.findById(userId).orElseThrow();
+        final List<UserWithLombokEqualsAndHashCode> users = userLombokRepository.findAll();
+
+        assertThrows(LazyInitializationException.class, () -> users.contains(user));
+    }
+
+    @Test
+    void whenProperEqualsAndHashCode_ThenSameEntityInstancesWithDifferentSecondaryFieldValuesAreEqual() {
+
+        final PhoneWithProperEqualsAndHashCode phone = phoneProperRepository.findById(phoneId).orElseThrow();
+        phone.setType("mobile");
+        final List<PhoneWithProperEqualsAndHashCode> phones = phoneProperRepository.findAll();
+
+        assertTrue(phones.contains(phone));
+    }
+
+    @Test
+    void whenProperEqualsAndHashCode_ThenDoesNotLoadFieldsWithLazyInitialization() {
+
+        final UserWithProperEqualsAndHashCode user = userProperRepository.findById(userId).orElseThrow();
+        final List<UserWithProperEqualsAndHashCode> users = userProperRepository.findAll();
+
+        assertTrue(users.contains(user));
+        assertFalse(Hibernate.isInitialized(user.getPhone()));
+    }
+
+    @Test
+    void whenLombokEqualsAndHashCodeAdjusted_ThenLoadFieldsForHibernateProxy() {
+
+        final PhoneWithLombokEqualsAndHashCodeAdjusted phone =
+                userLombokAdjustedRepository.findById(userId).orElseThrow().getPhone();
+        final List<PhoneWithLombokEqualsAndHashCodeAdjusted> phones = phoneLombokAdjustedRepository.findAll();
+
+        assertThrows(LazyInitializationException.class, () -> phones.contains(phone));
+    }
+
+    @Test
+    void whenProperEqualsAndHashCode_ThenDoesNotLoadFieldsForHibernateProxy() {
+
+        final PhoneWithProperEqualsAndHashCode phone = userProperRepository.findById(userId).orElseThrow().getPhone();
+        final List<PhoneWithProperEqualsAndHashCode> phones = phoneProperRepository.findAll();
+
+        assertTrue(phones.contains(phone));
+    }
+
+    @Test
+    void whenCustomEqualsAndHashCodeButIdGeneratedByHibernate_ThenEntityNotEqualBeforeAndAfterPersisted() {
+
+        final Set<PhoneWithCustomEqualsAndHashCode> phones = new HashSet<>();
+        final PhoneWithCustomEqualsAndHashCode phone = new PhoneWithCustomEqualsAndHashCode();
+        phone.setNumber("+123456789");
+        phone.setType("office");
+        phones.add(phone);
+        phoneCustomRepository.save(phone);
+
+        assertFalse(phones.contains(phone));
+    }
+
+    @Test
+    void whenProperEqualsAndHashCode_ThenEntityEqualBeforeAndAfterPersisted() {
+
+        final Set<PhoneWithProperEqualsAndHashCode> phones = new HashSet<>();
+        final PhoneWithProperEqualsAndHashCode phone = new PhoneWithProperEqualsAndHashCode();
+        phone.setNumber("+123456789");
+        phone.setType("office");
+        phones.add(phone);
+        phoneProperRepository.save(phone);
+
+        assertTrue(phones.contains(phone));
+    }
+}

--- a/src/test/java/io/github/akuniutka/model/PhoneWithCustomEqualsAndHashCode.java
+++ b/src/test/java/io/github/akuniutka/model/PhoneWithCustomEqualsAndHashCode.java
@@ -1,0 +1,53 @@
+package io.github.akuniutka.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "phones_custom")
+@Getter
+@Setter
+public class PhoneWithCustomEqualsAndHashCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String number;
+    private String type;
+
+    @Override
+    public final boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        final Class<?> thisEffectiveClass = this instanceof HibernateProxy proxy
+                ? proxy.getHibernateLazyInitializer().getPersistentClass()
+                : this.getClass();
+        final Class<?> objEffectiveClass = obj instanceof HibernateProxy proxy
+                ? proxy.getHibernateLazyInitializer().getPersistentClass()
+                : obj.getClass();
+        if (thisEffectiveClass != objEffectiveClass) {
+            return false;
+        }
+        final PhoneWithCustomEqualsAndHashCode entity = (PhoneWithCustomEqualsAndHashCode) obj;
+        return Objects.equals(getId(), entity.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(getId());
+    }
+}

--- a/src/test/java/io/github/akuniutka/model/PhoneWithDefaultEqualsAndHashCode.java
+++ b/src/test/java/io/github/akuniutka/model/PhoneWithDefaultEqualsAndHashCode.java
@@ -1,0 +1,25 @@
+package io.github.akuniutka.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "phones_default")
+@Getter
+@Setter
+public class PhoneWithDefaultEqualsAndHashCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String number;
+    private String type;
+}

--- a/src/test/java/io/github/akuniutka/model/PhoneWithLombokEqualsAndHashCode.java
+++ b/src/test/java/io/github/akuniutka/model/PhoneWithLombokEqualsAndHashCode.java
@@ -1,0 +1,27 @@
+package io.github.akuniutka.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "phones_lombok")
+@EqualsAndHashCode
+@Getter
+@Setter
+public class PhoneWithLombokEqualsAndHashCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String number;
+    private String type;
+}

--- a/src/test/java/io/github/akuniutka/model/PhoneWithLombokEqualsAndHashCodeAdjusted.java
+++ b/src/test/java/io/github/akuniutka/model/PhoneWithLombokEqualsAndHashCodeAdjusted.java
@@ -1,0 +1,27 @@
+package io.github.akuniutka.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "phones_lombok_adjusted")
+@EqualsAndHashCode(of = "id")
+@Getter
+@Setter
+public class PhoneWithLombokEqualsAndHashCodeAdjusted {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String number;
+    private String type;
+}

--- a/src/test/java/io/github/akuniutka/model/PhoneWithProperEqualsAndHashCode.java
+++ b/src/test/java/io/github/akuniutka/model/PhoneWithProperEqualsAndHashCode.java
@@ -1,0 +1,17 @@
+package io.github.akuniutka.model;
+
+import io.github.akuniutka.BaseJpaEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "phones_proper")
+@Getter
+@Setter
+public class PhoneWithProperEqualsAndHashCode extends BaseJpaEntity {
+
+    private String number;
+    private String type;
+}

--- a/src/test/java/io/github/akuniutka/model/UserWithCustomEqualsAndHashCode.java
+++ b/src/test/java/io/github/akuniutka/model/UserWithCustomEqualsAndHashCode.java
@@ -1,0 +1,58 @@
+package io.github.akuniutka.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users_custom")
+@Getter
+@Setter
+public class UserWithCustomEqualsAndHashCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+    private int age;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private PhoneWithCustomEqualsAndHashCode phone;
+
+    @Override
+    public final boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        final Class<?> thisEffectiveClass = this instanceof HibernateProxy proxy
+                ? proxy.getHibernateLazyInitializer().getPersistentClass()
+                : this.getClass();
+        final Class<?> objEffectiveClass = obj instanceof HibernateProxy proxy
+                ? proxy.getHibernateLazyInitializer().getPersistentClass()
+                : obj.getClass();
+        if (thisEffectiveClass != objEffectiveClass) {
+            return false;
+        }
+        final UserWithCustomEqualsAndHashCode entity = (UserWithCustomEqualsAndHashCode) obj;
+        return Objects.equals(getId(), entity.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(getId());
+    }
+}

--- a/src/test/java/io/github/akuniutka/model/UserWithDefaultEqualsAndHashCode.java
+++ b/src/test/java/io/github/akuniutka/model/UserWithDefaultEqualsAndHashCode.java
@@ -1,0 +1,30 @@
+package io.github.akuniutka.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "users_default")
+@Getter
+@Setter
+public class UserWithDefaultEqualsAndHashCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+    private int age;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private PhoneWithDefaultEqualsAndHashCode phone;
+}

--- a/src/test/java/io/github/akuniutka/model/UserWithLombokEqualsAndHashCode.java
+++ b/src/test/java/io/github/akuniutka/model/UserWithLombokEqualsAndHashCode.java
@@ -1,0 +1,32 @@
+package io.github.akuniutka.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "users_lombok")
+@EqualsAndHashCode
+@Getter
+@Setter
+public class UserWithLombokEqualsAndHashCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+    private int age;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private PhoneWithLombokEqualsAndHashCode phone;
+}

--- a/src/test/java/io/github/akuniutka/model/UserWithLombokEqualsAndHashCodeAdjusted.java
+++ b/src/test/java/io/github/akuniutka/model/UserWithLombokEqualsAndHashCodeAdjusted.java
@@ -1,0 +1,32 @@
+package io.github.akuniutka.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "users_lombok_adjusted")
+@EqualsAndHashCode(of = "id")
+@Getter
+@Setter
+public class UserWithLombokEqualsAndHashCodeAdjusted {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+    private int age;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private PhoneWithLombokEqualsAndHashCodeAdjusted phone;
+}

--- a/src/test/java/io/github/akuniutka/model/UserWithProperEqualsAndHashCode.java
+++ b/src/test/java/io/github/akuniutka/model/UserWithProperEqualsAndHashCode.java
@@ -1,0 +1,22 @@
+package io.github.akuniutka.model;
+
+import io.github.akuniutka.BaseJpaEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "users_proper")
+@Getter
+@Setter
+public class UserWithProperEqualsAndHashCode extends BaseJpaEntity {
+
+    private String name;
+    private int age;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private PhoneWithProperEqualsAndHashCode phone;
+}

--- a/src/test/java/io/github/akuniutka/repository/PhoneWithCustomEqualsAndHashCodeRepository.java
+++ b/src/test/java/io/github/akuniutka/repository/PhoneWithCustomEqualsAndHashCodeRepository.java
@@ -1,0 +1,11 @@
+package io.github.akuniutka.repository;
+
+import io.github.akuniutka.model.PhoneWithCustomEqualsAndHashCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PhoneWithCustomEqualsAndHashCodeRepository
+        extends JpaRepository<PhoneWithCustomEqualsAndHashCode, UUID> {
+
+}

--- a/src/test/java/io/github/akuniutka/repository/PhoneWithLombokEqualsAndHashCodeAdjustedRepository.java
+++ b/src/test/java/io/github/akuniutka/repository/PhoneWithLombokEqualsAndHashCodeAdjustedRepository.java
@@ -1,0 +1,11 @@
+package io.github.akuniutka.repository;
+
+import io.github.akuniutka.model.PhoneWithLombokEqualsAndHashCodeAdjusted;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PhoneWithLombokEqualsAndHashCodeAdjustedRepository
+        extends JpaRepository<PhoneWithLombokEqualsAndHashCodeAdjusted, UUID> {
+
+}

--- a/src/test/java/io/github/akuniutka/repository/PhoneWithLombokEqualsAndHashCodeRepository.java
+++ b/src/test/java/io/github/akuniutka/repository/PhoneWithLombokEqualsAndHashCodeRepository.java
@@ -1,0 +1,11 @@
+package io.github.akuniutka.repository;
+
+import io.github.akuniutka.model.PhoneWithLombokEqualsAndHashCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PhoneWithLombokEqualsAndHashCodeRepository
+        extends JpaRepository<PhoneWithLombokEqualsAndHashCode, UUID> {
+
+}

--- a/src/test/java/io/github/akuniutka/repository/PhoneWithProperEqualsAndHashCodeRepository.java
+++ b/src/test/java/io/github/akuniutka/repository/PhoneWithProperEqualsAndHashCodeRepository.java
@@ -1,0 +1,11 @@
+package io.github.akuniutka.repository;
+
+import io.github.akuniutka.model.PhoneWithProperEqualsAndHashCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PhoneWithProperEqualsAndHashCodeRepository
+        extends JpaRepository<PhoneWithProperEqualsAndHashCode, UUID> {
+
+}

--- a/src/test/java/io/github/akuniutka/repository/UserWithDefaultEqualsAndHashCodeRepository.java
+++ b/src/test/java/io/github/akuniutka/repository/UserWithDefaultEqualsAndHashCodeRepository.java
@@ -1,0 +1,11 @@
+package io.github.akuniutka.repository;
+
+import io.github.akuniutka.model.UserWithDefaultEqualsAndHashCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserWithDefaultEqualsAndHashCodeRepository
+        extends JpaRepository<UserWithDefaultEqualsAndHashCode, UUID> {
+
+}

--- a/src/test/java/io/github/akuniutka/repository/UserWithLombokEqualsAndHashCodeAdjustedRepository.java
+++ b/src/test/java/io/github/akuniutka/repository/UserWithLombokEqualsAndHashCodeAdjustedRepository.java
@@ -1,0 +1,11 @@
+package io.github.akuniutka.repository;
+
+import io.github.akuniutka.model.UserWithLombokEqualsAndHashCodeAdjusted;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserWithLombokEqualsAndHashCodeAdjustedRepository
+        extends JpaRepository<UserWithLombokEqualsAndHashCodeAdjusted, UUID> {
+
+}

--- a/src/test/java/io/github/akuniutka/repository/UserWithLombokEqualsAndHashCodeRepository.java
+++ b/src/test/java/io/github/akuniutka/repository/UserWithLombokEqualsAndHashCodeRepository.java
@@ -1,0 +1,11 @@
+package io.github.akuniutka.repository;
+
+import io.github.akuniutka.model.UserWithLombokEqualsAndHashCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserWithLombokEqualsAndHashCodeRepository
+        extends JpaRepository<UserWithLombokEqualsAndHashCode, UUID> {
+
+}

--- a/src/test/java/io/github/akuniutka/repository/UserWithProperEqualsAndHashCodeRepository.java
+++ b/src/test/java/io/github/akuniutka/repository/UserWithProperEqualsAndHashCodeRepository.java
@@ -1,0 +1,11 @@
+package io.github.akuniutka.repository;
+
+import io.github.akuniutka.model.UserWithProperEqualsAndHashCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserWithProperEqualsAndHashCodeRepository
+        extends JpaRepository<UserWithProperEqualsAndHashCode, UUID> {
+
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,14 @@
+spring:
+  main:
+    banner-mode: off
+  datasource:
+    url: jdbc:h2:mem:test
+    username: test
+    password: test
+  sql:
+    init:
+      mode: always
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,119 @@
+CREATE TABLE IF NOT EXISTS users_default
+(
+  id       UUID PRIMARY KEY,
+  name     VARCHAR NOT NULL,
+  age      INT     NOT NULL,
+  phone_id UUID
+);
+
+CREATE TABLE IF NOT EXISTS phones_default
+(
+  id     UUID PRIMARY KEY,
+  number VARCHAR NOT NULL,
+  type   VARCHAR NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS users_lombok
+(
+  id       UUID PRIMARY KEY,
+  name     VARCHAR NOT NULL,
+  age      INT     NOT NULL,
+  phone_id UUID
+);
+
+CREATE TABLE IF NOT EXISTS phones_lombok
+(
+  id     UUID PRIMARY KEY,
+  number VARCHAR NOT NULL,
+  type   VARCHAR NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS users_lombok_adjusted
+(
+  id       UUID PRIMARY KEY,
+  name     VARCHAR NOT NULL,
+  age      INT     NOT NULL,
+  phone_id UUID
+);
+
+CREATE TABLE IF NOT EXISTS phones_lombok_adjusted
+(
+  id     UUID PRIMARY KEY,
+  number VARCHAR NOT NULL,
+  type   VARCHAR NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS users_custom
+(
+  id       UUID PRIMARY KEY,
+  name     VARCHAR NOT NULL,
+  age      INT     NOT NULL,
+  phone_id UUID
+);
+
+CREATE TABLE IF NOT EXISTS phones_custom
+(
+  id     UUID PRIMARY KEY,
+  number VARCHAR NOT NULL,
+  type   VARCHAR NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS users_proper
+(
+  id       UUID PRIMARY KEY,
+  name     VARCHAR NOT NULL,
+  age      INT     NOT NULL,
+  phone_id UUID
+);
+
+CREATE TABLE IF NOT EXISTS phones_proper
+(
+  id     UUID PRIMARY KEY,
+  number VARCHAR NOT NULL,
+  type   VARCHAR NOT NULL
+);
+
+INSERT INTO users_default (id, name, age, phone_id)
+VALUES ('871bc1300b3649aeb631b298b95e9478', 'Alice', 20, '0749be042188491bb62c83c717c69671'),
+       ('dc6086523fb944a19556bfc425a58ea2', 'Bob', 42, null),
+       ('adab0f6011b249c0bfdcd24361dbb021', 'Charlie', 37, null);
+
+INSERT INTO phones_default (id, number, type)
+VALUES ('0749be042188491bb62c83c717c69671', '+123456789', 'office'),
+       ('3bc823dcd6f84544a612b07e84b7b88c', '+987654321', 'home');
+
+INSERT INTO users_lombok (id, name, age, phone_id)
+VALUES ('871bc1300b3649aeb631b298b95e9478', 'Alice', 20, '0749be042188491bb62c83c717c69671'),
+       ('dc6086523fb944a19556bfc425a58ea2', 'Bob', 42, null),
+       ('adab0f6011b249c0bfdcd24361dbb021', 'Charlie', 37, null);
+
+INSERT INTO phones_lombok (id, number, type)
+VALUES ('0749be042188491bb62c83c717c69671', '+123456789', 'office'),
+       ('3bc823dcd6f84544a612b07e84b7b88c', '+987654321', 'home');
+
+INSERT INTO users_lombok_adjusted (id, name, age, phone_id)
+VALUES ('871bc1300b3649aeb631b298b95e9478', 'Alice', 20, '0749be042188491bb62c83c717c69671'),
+       ('dc6086523fb944a19556bfc425a58ea2', 'Bob', 42, null),
+       ('adab0f6011b249c0bfdcd24361dbb021', 'Charlie', 37, null);
+
+INSERT INTO phones_lombok_adjusted (id, number, type)
+VALUES ('0749be042188491bb62c83c717c69671', '+123456789', 'office'),
+       ('3bc823dcd6f84544a612b07e84b7b88c', '+987654321', 'home');
+
+INSERT INTO users_custom (id, name, age, phone_id)
+VALUES ('871bc1300b3649aeb631b298b95e9478', 'Alice', 20, '0749be042188491bb62c83c717c69671'),
+       ('dc6086523fb944a19556bfc425a58ea2', 'Bob', 42, null),
+       ('adab0f6011b249c0bfdcd24361dbb021', 'Charlie', 37, null);
+
+INSERT INTO phones_custom (id, number, type)
+VALUES ('0749be042188491bb62c83c717c69671', '+123456789', 'office'),
+       ('3bc823dcd6f84544a612b07e84b7b88c', '+987654321', 'home');
+
+INSERT INTO users_proper (id, name, age, phone_id)
+VALUES ('871bc1300b3649aeb631b298b95e9478', 'Alice', 20, '0749be042188491bb62c83c717c69671'),
+       ('dc6086523fb944a19556bfc425a58ea2', 'Bob', 42, null),
+       ('adab0f6011b249c0bfdcd24361dbb021', 'Charlie', 37, null);
+
+INSERT INTO phones_proper (id, number, type)
+VALUES ('0749be042188491bb62c83c717c69671', '+123456789', 'office'),
+       ('3bc823dcd6f84544a612b07e84b7b88c', '+987654321', 'home');


### PR DESCRIPTION
Add class implementation and tests to compare it to:
- entity with default `equals()` and `hashCode()` implementations,
- entity with Lombok's `@EqualsAndHashCode` annotation,
- entity with Lombok's `@EqualsAndHashCode` annotation limited to `id` only,
- entity with adjusted `equals()` and `hashCode()` implementations but with `id` generated by Hibernate.