### PR TITLE
Make UUID generator a class static member

### DIFF
--- a/src/main/java/io/github/akuniutka/data/BaseHibernateEntity.java
+++ b/src/main/java/io/github/akuniutka/data/BaseHibernateEntity.java
@@ -1,6 +1,7 @@
 package io.github.akuniutka.data;
 
 import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import org.hibernate.proxy.HibernateProxy;
@@ -22,6 +23,8 @@ import java.util.UUID;
 @MappedSuperclass
 public abstract class BaseHibernateEntity {
 
+    private static final TimeBasedEpochGenerator uuidGenerator = Generators.timeBasedEpochGenerator();
+
     @Id
     private UUID id;
 
@@ -34,7 +37,7 @@ public abstract class BaseHibernateEntity {
      * to the entity on its creation.
      */
     protected BaseHibernateEntity() {
-        this(Generators.timeBasedEpochGenerator().generate());
+        this(uuidGenerator.generate());
     }
 
     protected BaseHibernateEntity(final UUID id) {


### PR DESCRIPTION
Optimize performance by making UUID generator a class static member instead of creating a new generator instance in every constructor call.