### PR TITLE
Remove UUID generator static field

### DIFF
--- a/src/main/java/io/github/akuniutka/data/BaseHibernateEntity.java
+++ b/src/main/java/io/github/akuniutka/data/BaseHibernateEntity.java
@@ -1,7 +1,6 @@
 package io.github.akuniutka.data;
 
 import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import org.hibernate.proxy.HibernateProxy;
@@ -23,8 +22,6 @@ import java.util.UUID;
 @MappedSuperclass
 public abstract class BaseHibernateEntity {
 
-    private static final TimeBasedEpochGenerator uuidGenerator = Generators.timeBasedEpochGenerator();
-
     @Id
     private UUID id;
 
@@ -37,7 +34,7 @@ public abstract class BaseHibernateEntity {
      * to the entity on its creation.
      */
     protected BaseHibernateEntity() {
-        this(uuidGenerator.generate());
+        this(Generators.timeBasedEpochGenerator().generate());
     }
 
     protected BaseHibernateEntity(final UUID id) {


### PR DESCRIPTION
Making UUID generator a static member was a premature optimization and led to:
- Another object which occupies memory for eternity
- More complex mocking in tests.

Postpone this optimization till there will be a need for it.